### PR TITLE
Fix to avgReps column index in LFC scaling. Fix to allow commas in in…

### DIFF
--- a/R/generic.R
+++ b/R/generic.R
@@ -130,7 +130,7 @@ process_column_indices <-
     if (length(columns) < 1 || is.null(columns))
       stop("Cannot process columns (<1 or null).")
     # Split character into a vector
-    columns <- columns %>% str_split(',', simplify = T)
+    columns <- columns %>% paste(collapse = ",") %>% str_split(',', simplify = T)
     # Loop through values and expand ranges
     processed_columns <- vector()
     for (i in 1:length(columns)) {

--- a/exec/scale_lfcs_and_bfs.R
+++ b/exec/scale_lfcs_and_bfs.R
@@ -100,7 +100,7 @@ if (ncol(sample_data) > 2) {
   message("Averaging replicates...")
   avg_sample_data <- average_replicates(data = sample_data,
                                         gene_column = 1,
-                                        data_columns = 2:(ncol(sample_data) - 1))
+                                        data_columns = 2:(ncol(sample_data)))
 } else {
   message("Only one data column, skipping averaging replicates.")
   avg_sample_data <- sample_data


### PR DESCRIPTION
Allow for columns to be processed in indices (when submitted from command line).
Allow all data columns when scaling LFCs