### PR TITLE
Feature/strip ids

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,22 @@
-# RCRISPR 1.0.0.0
+# RCRISPR NEXT
 
 ## Major changes
 
-Primarily documentation corrections
+* Enable guide ID stripping/reformating, see `strip_ids` option.
+
+## Bug fixes
+
+* Clean up check notes
+
+# RCRISPR 1.0.1.0
+
+## Major changes
+
+* Primarily documentation corrections
 
 ## Bug fixes
 
 NA
-
 
 # RCRISPR 1.0.0.0
 

--- a/R/bagel_classification.R
+++ b/R/bagel_classification.R
@@ -177,6 +177,7 @@ get_bagel_statistics <-
 #' @param gene_column index of column containing gene names.
 #' @param data_column index of column containing values.
 #' @param classification_column index of column containing BAGEL classifications.
+#' @param threshold cutoff value (Default: 0.05).
 #'
 #' @import dplyr
 #' @return dataframe

--- a/R/globals.R
+++ b/R/globals.R
@@ -44,7 +44,7 @@ utils::globalVariables(c("sgRNA", "gene", "Gene", 'sgrna',
                          "mean", "values", "median", "val", "ess", "median", "n_essential",
                          "total_essential", "n_nonessential", "total_essential", "n_nonessential",
                          "total_nonessential", "prop_bagel_essential", "setNames", "sd", "NNMD",
-                         "Essential.Glass.Delta"))
+                         "Essential.Glass.Delta", "FPR", "TPR", "coords"))
 
 
 

--- a/R/library_annotations.R
+++ b/R/library_annotations.R
@@ -40,6 +40,7 @@
 #' @param chr_end_column index of column containing chromosome position.
 #' @param file_separator library annotation file separator.
 #' @param file_header whether library annotation file contains a header.
+#' @param strip_ids whether to make syntactically valid id names.
 #' @param ... additional read.delim parameters.
 #'
 #' @return a data frame containing library annotations.
@@ -55,7 +56,7 @@ read_library_annotation_file <-
            chr_end_column = NULL,
            file_separator = "\t",
            file_header = TRUE,
-           stripIDs = FALSE,
+           strip_ids = FALSE,
            ...) {
     check_file(filepath)
     library_annotations <-
@@ -70,8 +71,8 @@ read_library_annotation_file <-
         assign(i, convert_variable_to_integer(get(i)))
     }
     #strip guide IDs if requested
-    if(stripIDs){
-      library_annotations[,id_column]<-gsub("[.]","",make.names(library_annotations[,id_column]))
+    if(strip_ids){
+      library_annotations[, id_column] <- gsub("[.]", "", make.names(library_annotations[, id_column]))
     }
     # Try reading library annotation into dataframe
     library_annotation_object <- tryCatch({

--- a/R/sample_counts.R
+++ b/R/sample_counts.R
@@ -60,6 +60,7 @@
 #' @param sample_name the sample name.
 #' @param file_separator count file separator.
 #' @param file_header whether count file(s) contain a header.
+#' @param strip_ids whether to make syntactically valid id names.
 #' @param ... additional read.delim parameters.
 #'
 #' @return a `SampleCounts` object.
@@ -74,7 +75,7 @@ read_sample_count_file <-
            count_column = 3,
            file_separator = "\t",
            file_header = TRUE,
-           stripIDs = FALSE,
+           strip_ids = FALSE,
            ...) {
     # Try reading sample counts into dataframe
     sample_counts <- tryCatch({
@@ -94,8 +95,8 @@ read_sample_count_file <-
         assign(i, convert_variable_to_integer(get(i)))
     }
     #strip ID column if requested
-    if(stripIDs){
-      sample_counts[,id_column]<-gsub("[.]","",make.names(sample_counts[,id_column]))
+    if(strip_ids){
+      sample_counts[,id_column] <- gsub("[.]", "", make.names(sample_counts[, id_column]))
     }
     # Try converting sample counts into a SampleCounts object
     sample_counts_object <- tryCatch({
@@ -213,6 +214,7 @@ convert_sample_counts_objects_to_count_matrix <-
 #' @param gene_column the index of column containing gene symbols.
 #' @param count_column vector indices of columns containing sample counts.
 #' @param processed logical of whether to apply predefined column names.
+#' @param strip_ids whether to make syntactically valid id names.
 #' @param ... additional read.delim parameters.
 #'
 #' @return a data frame containing sample counts.
@@ -225,7 +227,7 @@ read_count_matrix_file <-
            gene_column = 2,
            count_column = NULL,
            processed = FALSE,
-           stripIDs= FALSE,
+           strip_ids= FALSE,
            ...) {
     # Error out if count matrix has no header as we can't determine the sample names
     if (file_header == FALSE) {
@@ -245,8 +247,8 @@ read_count_matrix_file <-
       stop(e)
     })
     #strip ID column if requested:
-    if(stripIDs){
-      df[,id_column]<-gsub("[.]","",make.names(df[,id_column]))
+    if(strip_ids){
+      df[, id_column] <- gsub("[.]", "", make.names(df[, id_column]))
     }
     # Validate data frame
     check_dataframe(df, check_na = TRUE)
@@ -308,6 +310,7 @@ read_count_matrix_file <-
 #' @param file_separator count file separator.
 #' @param file_header whether count file(s) contain a header.
 #' @param sample_metadata_object a sample metadata object
+#' @param strip_ids whether to make syntactically valid id names.
 #' @param ... additional read.delim parameters.
 #'
 #' @return a list of `SampleCounts` objects.
@@ -319,7 +322,7 @@ read_sample_count_files <-
            count_column = 3,
            file_separator = "\t",
            file_header = TRUE,
-           stripIDs = FALSE,
+           strip_ids = FALSE,
            sample_metadata_object = NULL,
            ...) {
     # Try to make each column an integer if it isn't already
@@ -350,7 +353,7 @@ read_sample_count_files <-
                                                     count_column = count_column,
                                                     file_header = file_header,
                                                     file_separator = file_separator,
-                                                    stripIDs = stripIDs,
+                                                    strip_ids = strip_ids,
                                                     ...)
       # Add SampleCount object to list
       sample_count_objects <- c(sample_count_objects, sample_count_object)

--- a/man/prepare_essentiality_data.Rd
+++ b/man/prepare_essentiality_data.Rd
@@ -20,6 +20,8 @@ prepare_essentiality_data(
 \item{data_column}{index of column containing values.}
 
 \item{classification_column}{index of column containing BAGEL classifications.}
+
+\item{threshold}{cutoff value (Default: 0.05).}
 }
 \value{
 dataframe

--- a/man/read_count_matrix_file.Rd
+++ b/man/read_count_matrix_file.Rd
@@ -12,6 +12,7 @@ read_count_matrix_file(
   gene_column = 2,
   count_column = NULL,
   processed = FALSE,
+  strip_ids = FALSE,
   ...
 )
 }
@@ -29,6 +30,8 @@ read_count_matrix_file(
 \item{count_column}{vector indices of columns containing sample counts.}
 
 \item{processed}{logical of whether to apply predefined column names.}
+
+\item{strip_ids}{whether to make syntactically valid id names.}
 
 \item{...}{additional read.delim parameters.}
 }

--- a/man/read_library_annotation_file.Rd
+++ b/man/read_library_annotation_file.Rd
@@ -13,6 +13,7 @@ read_library_annotation_file(
   chr_end_column = NULL,
   file_separator = "\\t",
   file_header = TRUE,
+  strip_ids = FALSE,
   ...
 )
 }
@@ -32,6 +33,8 @@ read_library_annotation_file(
 \item{file_separator}{library annotation file separator.}
 
 \item{file_header}{whether library annotation file contains a header.}
+
+\item{strip_ids}{whether to make syntactically valid id names.}
 
 \item{...}{additional read.delim parameters.}
 }

--- a/man/read_sample_count_file.Rd
+++ b/man/read_sample_count_file.Rd
@@ -12,6 +12,7 @@ read_sample_count_file(
   count_column = 3,
   file_separator = "\\t",
   file_header = TRUE,
+  strip_ids = FALSE,
   ...
 )
 }
@@ -29,6 +30,8 @@ read_sample_count_file(
 \item{file_separator}{count file separator.}
 
 \item{file_header}{whether count file(s) contain a header.}
+
+\item{strip_ids}{whether to make syntactically valid id names.}
 
 \item{...}{additional read.delim parameters.}
 }

--- a/man/read_sample_count_files.Rd
+++ b/man/read_sample_count_files.Rd
@@ -11,6 +11,7 @@ read_sample_count_files(
   count_column = 3,
   file_separator = "\\t",
   file_header = TRUE,
+  strip_ids = FALSE,
   sample_metadata_object = NULL,
   ...
 )
@@ -27,6 +28,8 @@ read_sample_count_files(
 \item{file_separator}{count file separator.}
 
 \item{file_header}{whether count file(s) contain a header.}
+
+\item{strip_ids}{whether to make syntactically valid id names.}
 
 \item{sample_metadata_object}{a sample metadata object}
 


### PR DESCRIPTION
Allow guide ID stripping/reformatting.
Clean up documentation check notes.